### PR TITLE
Spigot-1.21.11 .

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,14 +5,16 @@
  * For more details on building Java & JVM projects, please refer to https://docs.gradle.org/8.4/userguide/building_java_projects.html in the Gradle documentation.
  */
 group = "jp.furplag.spigotmc.dynmap.extension"
-version = "1.4.0"
+version = "1.5.0-SNAPSHOT"
 description = "auto generate structure markers into Dynmap ."
 
-val paperSpigotVersion = "1.21.4-R0.1-SNAPSHOT"
+val paperSpigotVersion = "1.21.11-R0.2-SNAPSHOT"
+val lombokVersion = "1.18.42"
+
 plugins {
   // Apply the java-library plugin for API and implementation separation.
   `java-library`
-  id("com.diffplug.spotless") version "7.0.2"
+  id("com.diffplug.spotless") version "8.2.1"
   id("com.gradleup.shadow") version "8.3.0"  
 }
 repositories {
@@ -24,12 +26,12 @@ repositories {
 
 dependencies {
   compileOnly("org.spigotmc:spigot-api:${paperSpigotVersion}")
-  compileOnly("us.dynmap:DynmapCoreAPI:3.7-beta-6")
+  compileOnly("us.dynmap:DynmapCoreAPI:3.8")
 
-  compileOnly("org.projectlombok:lombok:1.18.36")
-  annotationProcessor("org.projectlombok:lombok:1.18.36")
+  compileOnly("org.projectlombok:lombok:${lombokVersion}")
+  annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
 
-  implementation("com.github.furplag:relic:5.1.0")
+  implementation("com.github.furplag:relic:v5.2.1")
 }
 
 spotless {

--- a/src/main/java/jp/furplag/spigotmc/dynmap/extension/StructureMarkers.java
+++ b/src/main/java/jp/furplag/spigotmc/dynmap/extension/StructureMarkers.java
@@ -138,6 +138,7 @@ public class StructureMarkers extends JavaPlugin implements Listener {
     });
   }
 
+  @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
   private void registerMarker(final ChunkLoadEvent event) {
     Trebuchet.Consumers.orNot(event, (_event) -> {
       Optional.ofNullable(Bukkit.getPluginManager().isPluginEnabled("dynmap") ? Bukkit.getPluginManager().getPlugin("dynmap") : null).ifPresent((plugin) -> {
@@ -150,7 +151,7 @@ public class StructureMarkers extends JavaPlugin implements Listener {
           .forEach((structureSearchResult) -> {
             final Location resultLocation = structureSearchResult.getLocation();
             marked.add(resultLocation);
-            final MarkerIconConfig icon = config.getMarkerIcon(structureSearchResult.getStructure().getKeyOrThrow().getKey());
+            final MarkerIconConfig icon = config.getMarkerIcon(Trebuchet.Functions.orNot(structureSearchResult.getStructure(), (structure) -> structure.getKey().getKey()));
             config.getMarkerSets().stream().filter((layer) -> layer.isRender(structureSearchResult.getStructure())).forEach((markerSetConfig) -> {
               final Set<String> unavailableIcons = new HashSet<>();
               final Set<String> unavailableLayers = new HashSet<>();

--- a/src/main/java/jp/furplag/spigotmc/dynmap/extension/StructureMarkers.java
+++ b/src/main/java/jp/furplag/spigotmc/dynmap/extension/StructureMarkers.java
@@ -128,7 +128,7 @@ public class StructureMarkers extends JavaPlugin implements Listener {
         markerSet.setHideByDefault(markerSetConfig.isHideByDefault());
         markerSet.setLayerPriority(markerSetConfig.getPriority());
         markerSet.setMinZoom(markerSetConfig.getMinZoom());
-        markerSet.setMinZoom(markerSetConfig.getMaxZoom());
+        markerSet.setMaxZoom(markerSetConfig.getMaxZoom());
         markerSet.setLabelShow(markerSetConfig.isLabelShow());
         Optional.ofNullable(Optional.ofNullable(markerAPI.getMarkerIcon(markerSetConfig.getIcon())).orElse(markerAPI.getMarkerIcon(config.getMarkerIconId(config.getMarkerIcon(markerSetConfig.getIcon())))))
           .ifPresent(markerSet::setDefaultMarkerIcon);
@@ -150,7 +150,7 @@ public class StructureMarkers extends JavaPlugin implements Listener {
           .forEach((structureSearchResult) -> {
             final Location resultLocation = structureSearchResult.getLocation();
             marked.add(resultLocation);
-            final MarkerIconConfig icon = config.getMarkerIcon(structureSearchResult.getStructure().getKey().getKey());
+            final MarkerIconConfig icon = config.getMarkerIcon(structureSearchResult.getStructure().getKeyOrThrow().getKey());
             config.getMarkerSets().stream().filter((layer) -> layer.isRender(structureSearchResult.getStructure())).forEach((markerSetConfig) -> {
               final Set<String> unavailableIcons = new HashSet<>();
               final Set<String> unavailableLayers = new HashSet<>();

--- a/src/main/java/jp/furplag/spigotmc/dynmap/extension/StructureMarkers.java
+++ b/src/main/java/jp/furplag/spigotmc/dynmap/extension/StructureMarkers.java
@@ -138,7 +138,7 @@ public class StructureMarkers extends JavaPlugin implements Listener {
     });
   }
 
-  @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
+  @SuppressWarnings({ "deprecation" }) // compatibility issue on PaperMC <-> SpigotMC
   private void registerMarker(final ChunkLoadEvent event) {
     Trebuchet.Consumers.orNot(event, (_event) -> {
       Optional.ofNullable(Bukkit.getPluginManager().isPluginEnabled("dynmap") ? Bukkit.getPluginManager().getPlugin("dynmap") : null).ifPresent((plugin) -> {

--- a/src/main/java/jp/furplag/spigotmc/dynmap/extension/config/Config.java
+++ b/src/main/java/jp/furplag/spigotmc/dynmap/extension/config/Config.java
@@ -118,7 +118,7 @@ public interface Config extends ConfigurationSerializable {
        */
       private final String icon;
 
-      @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
+      @SuppressWarnings({ "deprecation" }) // compatibility issue on PaperMC <-> SpigotMC
       private static final List<MarkerIconConfig> deserialize(final ConfigurationSection config) {
         return Stream.concat(Stream.of(_defaults), Registry.STRUCTURE.stream()
         	.flatMap((structure) -> Stream.of(Trebuchet.Functions.orNot(structure, (_structure) -> _structure.getKey().getKey()), Trebuchet.Functions.orNot(structure.getStructureType(), (structureType) -> structureType.getKey().getKey())))
@@ -221,7 +221,7 @@ public interface Config extends ConfigurationSerializable {
         return "%s%s".formatted(Trebuchet.Functions.orElse(icon, MarkerIconConfig::getLabel, () -> label), labelWithCoordinates ? " [ %d, %d ]".formatted(location.getBlockX(), location.getBlockZ()) : "");
       }
 
-      @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
+      @SuppressWarnings({ "deprecation" }) // compatibility issue on PaperMC <-> SpigotMC
       public boolean isRender(final Structure structure) {
         return structures.isEmpty() || Trebuchet.Predicates.orElse(structure, (_structure) -> structures.contains((_structure.getKey()).getKey()), (t, ex) -> true);
       }

--- a/src/main/java/jp/furplag/spigotmc/dynmap/extension/config/Config.java
+++ b/src/main/java/jp/furplag/spigotmc/dynmap/extension/config/Config.java
@@ -16,8 +16,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
-
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -27,6 +25,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.bukkit.generator.structure.Structure;
+import org.jetbrains.annotations.NotNull;
 
 import com.google.common.base.CaseFormat;
 
@@ -102,7 +101,7 @@ public interface Config extends ConfigurationSerializable {
       private static final MarkerIconConfig _defaults = new MarkerIconConfig("_unresolved", "Unknown Structure", null);
 
       /** identity of {@link org.dynmap.markers.MarkerIcon MarkerIcon} */
-      private final @Nonnull String id;
+      private final @NotNull String id;
 
       /**
        * <p>the name use to display marker into the map .</p>
@@ -119,6 +118,7 @@ public interface Config extends ConfigurationSerializable {
        */
       private final String icon;
 
+      @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
       private static final List<MarkerIconConfig> deserialize(final ConfigurationSection config) {
         return Stream.concat(Stream.of(_defaults), Registry.STRUCTURE.stream().flatMap((structure) -> Stream.of(structure.getKey().getKey(), structure.getStructureType().getKey().getKey())).map((id) -> id.split(":")).map((ids) -> ids[ids.length - 1])
           .distinct().map((id) -> deserialize(id, config.getConfigurationSection("marker-icons.%s".formatted(id)))).filter(Objects::nonNull)
@@ -160,7 +160,7 @@ public interface Config extends ConfigurationSerializable {
     public static class MarkerSetConfig implements Config {
 
       /** identity of {@link org.dynmap.markers.MarkerSet MarkerSet} */
-      private final @Nonnull String id;
+      private final @NotNull String id;
 
       /**
        * <p>the name use to display marker layer toggles .</p>
@@ -219,8 +219,9 @@ public interface Config extends ConfigurationSerializable {
         return "%s%s".formatted(Trebuchet.Functions.orElse(icon, MarkerIconConfig::getLabel, () -> label), labelWithCoordinates ? " [ %d, %d ]".formatted(location.getBlockX(), location.getBlockZ()) : "");
       }
 
+      @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
       public boolean isRender(final Structure structure) {
-        return structures.isEmpty() || structures.contains(structure.getKey().getKey());
+        return structures.isEmpty() || Trebuchet.Predicates.orElse(structure, (_structure) -> structures.contains((_structure.getKey()).getKey()), (t, ex) -> true);
       }
 
       /** {@inheritDoc} */ @Override public Map<String, Object> serialize() {

--- a/src/main/java/jp/furplag/spigotmc/dynmap/extension/config/Config.java
+++ b/src/main/java/jp/furplag/spigotmc/dynmap/extension/config/Config.java
@@ -120,7 +120,9 @@ public interface Config extends ConfigurationSerializable {
 
       @SuppressWarnings({ "deprecation" }) /** compatibility issue on PaperMC <-> SpigotMC */
       private static final List<MarkerIconConfig> deserialize(final ConfigurationSection config) {
-        return Stream.concat(Stream.of(_defaults), Registry.STRUCTURE.stream().flatMap((structure) -> Stream.of(structure.getKey().getKey(), structure.getStructureType().getKey().getKey())).map((id) -> id.split(":")).map((ids) -> ids[ids.length - 1])
+        return Stream.concat(Stream.of(_defaults), Registry.STRUCTURE.stream()
+        	.flatMap((structure) -> Stream.of(Trebuchet.Functions.orNot(structure, (_structure) -> _structure.getKey().getKey()), Trebuchet.Functions.orNot(structure.getStructureType(), (structureType) -> structureType.getKey().getKey())))
+        	.filter(Objects::nonNull).map((id) -> id.split(":")).map((ids) -> ids[ids.length - 1])
           .distinct().map((id) -> deserialize(id, config.getConfigurationSection("marker-icons.%s".formatted(id)))).filter(Objects::nonNull)
         ).sorted(Comparator.comparing(MarkerIconConfig::getId)).collect(Collectors.toUnmodifiableList());
       }


### PR DESCRIPTION
* refactor .
* update dependencies .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected zoom assignment for marker sets.
  * Improved marker icon resolution and rendering with null-safe handling and compatibility adjustments.

* **Chores**
  * Bumped project version to 1.5.0-SNAPSHOT.
  * Centralized Lombok version and upgraded dependencies (Paper/Spigot, Spotless, Dynmap API, relic) for improved compatibility and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->